### PR TITLE
Implementierung case (in)sensitive konfigurierbare Suche

### DIFF
--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/common/konstanten/KonfigurationsSchluessel.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/common/konstanten/KonfigurationsSchluessel.java
@@ -30,4 +30,5 @@ public abstract class KonfigurationsSchluessel {
     public static final String CONF_ZUGRIFFSVERWALTUNG_MAX_FEHLANMELDEVERSUCHE =
         "benutzerverwaltung.maxfehlanmeldeversuche";
 
+    public static final String SUCHE_CASE_SENSITIVE = "benutzerverwaltung.suche.casesensitive";
 }

--- a/isy-benutzerverwaltung-core/src/main/resources/resources/isy-benutzerverwaltung/spring/persistence/dao.xml
+++ b/isy-benutzerverwaltung-core/src/main/resources/resources/isy-benutzerverwaltung/spring/persistence/dao.xml
@@ -37,12 +37,14 @@
         <property name="entityManager" ref="entityManagerFactoryBean"/>
     </bean>
 
-    <bean class="de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaBenutzerDao"
-          id="benutzerDao"
-          parent="abstractDao"/>
+    <bean id="benutzerDao" class="de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaBenutzerDao"
+          parent="abstractDao">
+        <constructor-arg ref="konfiguration"/>
+    </bean>
 
-    <bean id="rollenDao"
-          class="de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaRollenDao"
-          parent="abstractDao"/>
+    <bean id="rollenDao" class="de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaRollenDao"
+          parent="abstractDao">
+        <constructor-arg ref="konfiguration"/>
+    </bean>
 
 </beans>

--- a/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/core/TestfallKonfiguration.java
+++ b/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/core/TestfallKonfiguration.java
@@ -21,6 +21,7 @@ package de.bund.bva.isyfact.benutzerverwaltung.core;
  */
 
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.TestPersistenceConfiguration;
+import de.bund.bva.pliscommon.konfiguration.common.Konfiguration;
 import de.bund.bva.pliscommon.util.spring.MessageSourceHolder;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.support.ResourceBundleMessageSource;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Enthält die Konfiguration für einen Testfall.
@@ -38,6 +41,8 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 @Import(TestPersistenceConfiguration.class)
 @ImportResource("classpath:resources/isy-benutzerverwaltung/spring/isy-benutzerverwaltung-core-modul.xml")
 public class TestfallKonfiguration {
+
+    public static Konfiguration konfiguration = mock(Konfiguration.class);
 
     private static final String[] BASENAMES = { "resources/isy-benutzerverwaltung/nachrichten/fehler",
         "resources/isy-benutzerverwaltung/nachrichten/hinweise",
@@ -53,6 +58,11 @@ public class TestfallKonfiguration {
     @Bean
     public MessageSourceHolder messageSourceHolder() {
         return new MessageSourceHolder();
+    }
+
+    @Bean
+    public Konfiguration konfiguration() {
+        return konfiguration;
     }
 
 }

--- a/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/BenutzerDaoTest.java
+++ b/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/BenutzerDaoTest.java
@@ -1,4 +1,4 @@
-package de.bund.bva.isyfact.benutzerverwaltung.persistence.benutzerverwaltung;
+package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao;
 
 /*-
  * #%L
@@ -20,35 +20,32 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.benutzerverwaltung;
  * #L%
  */
 
-
+import com.github.springtestdbunit.annotation.DatabaseSetup;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Paginierung;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierrichtung;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierung;
+import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.KonfigurationsSchluessel;
 import de.bund.bva.isyfact.benutzerverwaltung.core.TestfallKonfiguration;
 import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerSortierattribut;
 import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerStatus;
 import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerSuchkriterien;
-import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.BenutzerDao;
-import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.RollenDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Benutzer;
-import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Rolle;
+import de.bund.bva.isyfact.test.AbstractSpringDbUnitTest;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+
 @ContextConfiguration(classes = TestfallKonfiguration.class)
-@Transactional
-public class BenutzerDaoTest {
+@DatabaseSetup("BenutzerverwaltungPersistenceTestSetup.xml")
+public class BenutzerDaoTest extends AbstractSpringDbUnitTest {
 
     @Autowired
     protected BenutzerDao benutzerDao;
@@ -58,31 +55,10 @@ public class BenutzerDaoTest {
 
     private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    private Benutzer erzeugeBenutzerInDb(String benutzername, String passwort, BenutzerStatus status,
-        String... rollen) {
-        Benutzer benutzer = new Benutzer();
-        benutzer.setBenutzername(benutzername);
-
-        // Setze Passwort
-        String passwortHash = passwordEncoder.encode(passwort);
-        benutzer.setPasswort(passwortHash);
-        benutzer.setStatus(status);
-
-        for (String rolle : rollen) {
-            Rolle neueRolle = new Rolle();
-            neueRolle.setId(rolle);
-            neueRolle.setName(rolle);
-            rollenDao.speichere(neueRolle);
-            benutzer.getRollen().add(neueRolle);
-        }
-
-        benutzerDao.speichere(benutzer);
-        return benutzer;
-    }
-
     @Test
-    public void benutzerFilterTest() {
-        erzeugeBenutzerInDb("test", "geheim", BenutzerStatus.AKTIVIERT, "Rolle1", "Rolle2");
+    public void testSucheMitBenutzerFilterCaseSensitive() {
+        when(TestfallKonfiguration.konfiguration.getAsBoolean(KonfigurationsSchluessel.SUCHE_CASE_SENSITIVE, false)).thenReturn(true);
+
         BenutzerSuchkriterien benutzerFilter = new BenutzerSuchkriterien();
         benutzerFilter.setBenutzername("test");
         benutzerFilter.setStatus(BenutzerStatus.AKTIVIERT);
@@ -96,15 +72,31 @@ public class BenutzerDaoTest {
             benutzerDao.sucheMitBenutzerFilter(benutzerFilter, sortierung, paginierung);
 
         assertEquals(1, benutzerListe.size());
-
     }
 
     @Test
-    public void getBenutzerZuRollenTest() {
-        Benutzer benutzer = erzeugeBenutzerInDb("DASISTEINTEST", "geheim", null, "RolleId_1");
+    public void testSucheMitBenutzerFilterCaseInsensitive() {
+        when(TestfallKonfiguration.konfiguration.getAsBoolean(KonfigurationsSchluessel.SUCHE_CASE_SENSITIVE, false)).thenReturn(false);
+
         BenutzerSuchkriterien benutzerFilter = new BenutzerSuchkriterien();
-        benutzerFilter.setRollenId("RolleId_1");
-        benutzerFilter.setBenutzername("DASISTEINTEST");
+        benutzerFilter.setBenutzername("test");
+        benutzerFilter.setStatus(BenutzerStatus.AKTIVIERT);
+
+        Sortierung sortierung =
+            new Sortierung(BenutzerSortierattribut.BENUTZERNAME, Sortierrichtung.ABSTEIGEND);
+
+        Paginierung paginierung = new Paginierung(0, 100);
+
+        List<Benutzer> benutzerListe =
+            benutzerDao.sucheMitBenutzerFilter(benutzerFilter, sortierung, paginierung);
+
+        assertEquals(2, benutzerListe.size());
+    }
+
+    @Test
+    public void testSucheBenutzerZuRollen() {
+        BenutzerSuchkriterien benutzerFilter = new BenutzerSuchkriterien();
+        benutzerFilter.setRollenId("idrolle1");
 
         Sortierung sortierung = new Sortierung(BenutzerSortierattribut.NACHNAME, Sortierrichtung.ABSTEIGEND);
         Paginierung paginierung = new Paginierung(0, 100);
@@ -113,9 +105,5 @@ public class BenutzerDaoTest {
             benutzerDao.sucheMitBenutzerFilter(benutzerFilter, sortierung, paginierung);
 
         assertEquals(1, benutzerListe.size());
-
-        benutzerDao.loesche(benutzer);
-        benutzerListe = benutzerDao.sucheMitBenutzerFilter(benutzerFilter, sortierung, paginierung);
-        assertEquals(0, benutzerListe.size());
     }
 }

--- a/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/RollenDaoTest.java
+++ b/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/RollenDaoTest.java
@@ -1,0 +1,104 @@
+package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao;
+
+/*-
+ * #%L
+ * IsyFact Benutzerverwaltung Core
+ * %%
+ * Copyright (C) 2016 - 2017 Bundesverwaltungsamt (BVA)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Paginierung;
+import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierrichtung;
+import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierung;
+import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.KonfigurationsSchluessel;
+import de.bund.bva.isyfact.benutzerverwaltung.core.TestfallKonfiguration;
+import de.bund.bva.isyfact.benutzerverwaltung.core.rollenverwaltung.RolleSortierattribut;
+import de.bund.bva.isyfact.benutzerverwaltung.core.rollenverwaltung.RolleSuchkriterien;
+import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Rolle;
+import de.bund.bva.isyfact.test.AbstractSpringDbUnitTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Björn Saxe, msg systems ag
+ */
+
+@ContextConfiguration(classes = TestfallKonfiguration.class)
+@DatabaseSetup("BenutzerverwaltungPersistenceTestSetup.xml")
+public class RollenDaoTest extends AbstractSpringDbUnitTest {
+
+    @Autowired
+    private RollenDao rollenDao;
+
+    @Test
+    public void testSucheMitRollenId() throws Exception {
+        Rolle ergebnis = rollenDao.sucheMitRollenId("idrolle1");
+
+        assertEquals("idrolle1", ergebnis.getId());
+    }
+
+    @Test
+    public void testSucheMitRollenIds() throws Exception {
+        List<Rolle> ergebnis = rollenDao.sucheMitRollenIds(Arrays.asList("idrolle1", "idrolle2"));
+
+        assertEquals(2, ergebnis.size());
+    }
+
+    @Test
+    public void testSucheMitFilterCaseSensitive() throws Exception {
+        when(TestfallKonfiguration.konfiguration.getAsBoolean(KonfigurationsSchluessel.SUCHE_CASE_SENSITIVE, false)).thenReturn(true);
+
+        RolleSuchkriterien suchkriterien = new RolleSuchkriterien();
+        suchkriterien.setId("idrolle1");
+        suchkriterien.setName("namerolle1");
+
+        Sortierung sortierung =
+            new Sortierung(RolleSortierattribut.ID, Sortierrichtung.ABSTEIGEND);
+
+        Paginierung paginierung = new Paginierung(0, 100);
+
+        List<Rolle> ergebnis = rollenDao.sucheMitFilter(suchkriterien, sortierung, paginierung);
+
+        assertEquals(1, ergebnis.size());
+        assertEquals("idrolle1", ergebnis.get(0).getId());
+        assertEquals("namerolle1", ergebnis.get(0).getName());
+    }
+
+    @Test
+    public void testSucheMitFilterCaseInsensitive() throws Exception {
+        when(TestfallKonfiguration.konfiguration.getAsBoolean(KonfigurationsSchluessel.SUCHE_CASE_SENSITIVE, false)).thenReturn(false);
+
+        RolleSuchkriterien suchkriterien = new RolleSuchkriterien();
+        suchkriterien.setId("idrolle1");
+
+        Sortierung sortierung =
+            new Sortierung(RolleSortierattribut.ID, Sortierrichtung.ABSTEIGEND);
+
+        Paginierung paginierung = new Paginierung(0, 100);
+
+        List<Rolle> ergebnis = rollenDao.sucheMitFilter(suchkriterien, sortierung, paginierung);
+
+        assertEquals(2, ergebnis.size());
+    }
+}

--- a/isy-benutzerverwaltung-core/src/test/resources/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/BenutzerverwaltungPersistenceTestSetup.xml
+++ b/isy-benutzerverwaltung-core/src/test/resources/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/BenutzerverwaltungPersistenceTestSetup.xml
@@ -1,0 +1,43 @@
+<!--
+  #%L
+  IsyFact Benutzerverwaltung Core
+  %%
+  Copyright (C) 2016 - 2017 Bundesverwaltungsamt (BVA)
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<dataset>
+    <Rolle primaryKey="101" id="idrolle1" name="namerolle1" version="0"/>
+    <Rolle primaryKey="102" id="IdRolle1" name="NameRolle1" version="0"/>
+    <Rolle primaryKey="103" id="idrolle2" name="namerolle2" version="0"/>
+    <Rolle primaryKey="104" id="IdRolle2" name="NameRolle2" version="0"/>
+
+    <Benutzer id="201" benutzername="test"
+              passwort="$2a$10$lj4tBJe5luAEI6g7iOZ75uiVvyHgQgn6oQjZNJRIQdQt7fPzvyQRy"
+              behoerde="BFJA" nachname="Tester" vorname="Klaus" status="2" fehlanmeldeVersuche="5"
+              letzteAnmeldung="2016-01-01" letzteAbmeldung="2016-01-02" bemerkung="Testexperte"
+              emailAdresse="klaus.tester@behoerde.de" telefonnummer="0123/456789" version="0"/>
+
+    <Benutzer id="202" benutzername="Test"
+              passwort="$2a$10$lj4tBJe5luAEI6g7iOZ75uiVvyHgQgn6oQjZNJRIQdQt7fPzvyQRy"
+              behoerde="BFJA" nachname="Tester" vorname="Jürgen" status="2" fehlanmeldeVersuche="0"
+              letzteAnmeldung="2016-04-01" letzteAbmeldung="2016-04-01" bemerkung="Superuser"
+              emailAdresse="juergen.tester@behoerde.de" telefonnummer="0121/456799" version="0"/>
+
+    <Benutzer_Rollen Benutzer_PK="201" Rolle_PK="101"/>
+    <Benutzer_Rollen Benutzer_PK="201" Rolle_PK="102"/>
+    <Benutzer_Rollen Benutzer_PK="202" Rolle_PK="103"/>
+    <Benutzer_Rollen Benutzer_PK="202" Rolle_PK="102"/>
+</dataset>

--- a/isy-benutzerverwaltung-gui-primefaces/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/gui/TestPersistenceConfiguration.java
+++ b/isy-benutzerverwaltung-gui-primefaces/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/gui/TestPersistenceConfiguration.java
@@ -22,6 +22,7 @@ package de.bund.bva.isyfact.benutzerverwaltung.gui;
 
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.BenutzerDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaBenutzerDao;
+import de.bund.bva.pliscommon.konfiguration.common.impl.ReloadablePropertyKonfiguration;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.context.annotation.Bean;
@@ -48,7 +49,6 @@ import javax.sql.DataSource;
 @Configuration
 @EnableTransactionManagement
 public class TestPersistenceConfiguration {
-
     @Bean
     public DataSource dataSource() {
         JdbcDataSource dataSource = new JdbcDataSource();
@@ -94,9 +94,8 @@ public class TestPersistenceConfiguration {
 
     @Bean
     public BenutzerDao benutzerDao(EntityManager entityManager) {
-        JpaBenutzerDao dao = new JpaBenutzerDao();
+        JpaBenutzerDao dao = new JpaBenutzerDao(new ReloadablePropertyKonfiguration(new String[] {}));
         dao.setEntityManager(entityManager);
         return dao;
     }
-
 }

--- a/isy-benutzerverwaltung-gui-tomahawk/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/gui/TestPersistenceConfiguration.java
+++ b/isy-benutzerverwaltung-gui-tomahawk/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/gui/TestPersistenceConfiguration.java
@@ -22,6 +22,7 @@ package de.bund.bva.isyfact.benutzerverwaltung.gui;
 
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.BenutzerDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaBenutzerDao;
+import de.bund.bva.pliscommon.konfiguration.common.impl.ReloadablePropertyKonfiguration;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.context.annotation.Bean;
@@ -92,9 +93,10 @@ public class TestPersistenceConfiguration {
         return new PersistenceExceptionTranslationPostProcessor();
     }
 
+
     @Bean
     public BenutzerDao benutzerDao(EntityManager entityManager) {
-        JpaBenutzerDao dao = new JpaBenutzerDao();
+        JpaBenutzerDao dao = new JpaBenutzerDao(new ReloadablePropertyKonfiguration(new String[] {}));
         dao.setEntityManager(entityManager);
         return dao;
     }

--- a/isy-benutzerverwaltung-sicherheit/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/TestPersistenceConfiguration.java
+++ b/isy-benutzerverwaltung-sicherheit/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/TestPersistenceConfiguration.java
@@ -22,6 +22,7 @@ package de.bund.bva.isyfact.benutzerverwaltung;
 
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.BenutzerDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa.JpaBenutzerDao;
+import de.bund.bva.pliscommon.konfiguration.common.impl.ReloadablePropertyKonfiguration;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.context.annotation.Bean;
@@ -94,7 +95,7 @@ public class TestPersistenceConfiguration {
 
     @Bean
     public BenutzerDao benutzerDao(EntityManager entityManager) {
-        JpaBenutzerDao dao = new JpaBenutzerDao();
+        JpaBenutzerDao dao = new JpaBenutzerDao(new ReloadablePropertyKonfiguration(new String[] {}));
         dao.setEntityManager(entityManager);
         return dao;
     }


### PR DESCRIPTION
Die Groß/Kleinschreibung kann über den Konfigurationsparameter `benutzerverwaltung.suche.casesensitive=true / false` gesteuert werden. Standardwert ist `false`.