### PR TITLE
Neue Maske für Rollenzuweisung

### DIFF
--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/core/benutzerverwaltung/impl/AwfBenutzerVerwalten.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/core/benutzerverwaltung/impl/AwfBenutzerVerwalten.java
@@ -20,6 +20,11 @@ package de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.impl;
  * #L%
  */
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.Validator;
 
 import de.bund.bva.isyfact.benutzerverwaltung.common.exception.BenutzerverwaltungBusinessException;
 import de.bund.bva.isyfact.benutzerverwaltung.common.exception.BenutzerverwaltungTechnicalRuntimeException;
@@ -28,7 +33,11 @@ import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.FehlerSchluessel
 import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.ValidierungSchluessel;
 import de.bund.bva.isyfact.benutzerverwaltung.core.basisdaten.daten.RolleDaten;
 import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerStatus;
-import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.*;
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.BenutzerAendern;
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.BenutzerAnlegen;
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.BenutzerSelbstAendern;
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.PasswortAendern;
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.daten.PasswortZuruecksetzen;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.BenutzerDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.RollenDao;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Benutzer;
@@ -36,11 +45,6 @@ import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Roll
 import de.bund.bva.isyfact.logging.IsyLogger;
 import de.bund.bva.isyfact.logging.IsyLoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import javax.validation.Validator;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Diese Klasse bietet Funktionalität zum Erstellen, Bearbeiten und Loeschen
@@ -278,9 +282,9 @@ class AwfBenutzerVerwalten extends AbstractAnwendungsfall {
         }
     }
 
-    private List<Rolle> konvertiereRollen(List<RolleDaten> rolleDaten) {
+    private Set<Rolle> konvertiereRollen(List<RolleDaten> rolleDaten) {
         if (rolleDaten == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
 
         List<String> rollenIds =

--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/RollenDao.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/RollenDao.java
@@ -20,14 +20,15 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao;
  * #L%
  */
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Paginierung;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierung;
 import de.bund.bva.isyfact.benutzerverwaltung.core.rollenverwaltung.RolleSuchkriterien;
 import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Rolle;
 import de.bund.bva.pliscommon.persistence.dao.Dao;
-
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Beschreibt den Datenbankzugriff für Rollen.
@@ -50,7 +51,7 @@ public interface RollenDao extends Dao<Rolle, Long> {
      * @param rollenIds IDs der Rollen
      * @return eine Liste aller Rollen, die zu den IDs gefunden wurden.
      */
-    List<Rolle> sucheMitRollenIds(Collection<String> rollenIds);
+    Set<Rolle> sucheMitRollenIds(Collection<String> rollenIds);
 
     /**
      * Diese Methode filtert und sortiert eine Treffermenge an Rollen und gibt diese zurueck.

--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/jpa/JpaRollenDao.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/jpa/JpaRollenDao.java
@@ -20,6 +20,14 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa;
  * #L%
  */
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.TypedQuery;
+
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.ComparableExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -36,12 +44,6 @@ import de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity.Roll
 import de.bund.bva.pliscommon.konfiguration.common.Konfiguration;
 import de.bund.bva.pliscommon.persistence.dao.AbstractDao;
 import org.springframework.beans.factory.InitializingBean;
-
-import javax.persistence.TypedQuery;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Implementiert den Datenbankzugriff für Rollen mittels JPA.
@@ -74,11 +76,11 @@ public class JpaRollenDao extends AbstractDao<Rolle, Long> implements RollenDao,
     }
 
     @Override
-    public List<Rolle> sucheMitRollenIds(Collection<String> rollenIds) {
+    public Set<Rolle> sucheMitRollenIds(Collection<String> rollenIds) {
         TypedQuery<Rolle> query =
             getEntityManager().createNamedQuery(NamedQuerySchluessel.SUCHE_ROLLE_IDS, Rolle.class);
         query.setParameter("ids", rollenIds);
-        return query.getResultList();
+        return new HashSet<>(query.getResultList());
     }
 
     @Override

--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/entity/Benutzer.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/entity/Benutzer.java
@@ -20,15 +20,23 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity;
  * #L%
  */
 
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Version;
 
 import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.NamedQuerySchluessel;
 import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerStatus;
-
-import javax.persistence.*;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 /**
  * Die persistente Entität eines {@link Benutzer}s.
@@ -69,7 +77,7 @@ public class Benutzer implements Serializable {
 
     private String telefonnummer;
 
-    private List<Rolle> rollen = new ArrayList<>();
+    private Set<Rolle> rollen = new HashSet<>();
 
     private int version;
 
@@ -319,7 +327,7 @@ public class Benutzer implements Serializable {
     @JoinTable(name = "Benutzer_Rollen",
                joinColumns = @JoinColumn(name = "Benutzer_PK", referencedColumnName = "id"),
                inverseJoinColumns = @JoinColumn(name = "Rolle_PK", referencedColumnName = "primarykey"))
-    public List<Rolle> getRollen() {
+    public Set<Rolle> getRollen() {
         return rollen;
     }
 
@@ -328,7 +336,7 @@ public class Benutzer implements Serializable {
      *
      * @param rollen neue Rollen
      */
-    public void setRollen(List<Rolle> rollen) {
+    public void setRollen(Set<Rolle> rollen) {
         this.rollen = rollen;
     }
 

--- a/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/entity/Rolle.java
+++ b/isy-benutzerverwaltung-core/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/entity/Rolle.java
@@ -20,10 +20,16 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.entity;
  * #L%
  */
 
-import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.NamedQuerySchluessel;
-
-import javax.persistence.*;
 import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Version;
+
+import de.bund.bva.isyfact.benutzerverwaltung.common.konstanten.NamedQuerySchluessel;
 
 /**
  * Die persistente Entität einer {@link Rolle}.
@@ -123,4 +129,20 @@ public class Rolle implements Serializable {
         this.version = version;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Rolle rolle = (Rolle) o;
+        return Objects.equals(id, rolle.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/jpa/JpaRollenDaoTest.java
+++ b/isy-benutzerverwaltung-core/src/test/java/de/bund/bva/isyfact/benutzerverwaltung/persistence/basisdaten/dao/jpa/JpaRollenDaoTest.java
@@ -20,6 +20,10 @@ package de.bund.bva.isyfact.benutzerverwaltung.persistence.basisdaten.dao.jpa;
  * #L%
  */
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Paginierung;
 import de.bund.bva.isyfact.benutzerverwaltung.common.datentyp.Sortierrichtung;
@@ -34,9 +38,6 @@ import de.bund.bva.isyfact.test.AbstractSpringDbUnitTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -61,7 +62,7 @@ public class JpaRollenDaoTest extends AbstractSpringDbUnitTest {
 
     @Test
     public void testSucheMitRollenIds() throws Exception {
-        List<Rolle> ergebnis = rollenDao.sucheMitRollenIds(Arrays.asList("idrolle1", "idrolle2"));
+        Set<Rolle> ergebnis = rollenDao.sucheMitRollenIds(Arrays.asList("idrolle1", "idrolle2"));
 
         assertEquals(2, ergebnis.size());
     }

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/gui/benutzerverwaltung/rollenzuweisung/RollenZuweisungModel.java
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/gui/benutzerverwaltung/rollenzuweisung/RollenZuweisungModel.java
@@ -20,12 +20,15 @@ package de.bund.bva.isyfact.benutzerverwaltung.gui.benutzerverwaltung.rollenzuwe
  * #L%
  */
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import de.bund.bva.isyfact.benutzerverwaltung.core.benutzerverwaltung.BenutzerStatus;
+import de.bund.bva.isyfact.benutzerverwaltung.gui.benutzerverwaltung.benutzersuchen.BenutzerSuchkriterienModel;
 import de.bund.bva.isyfact.benutzerverwaltung.gui.common.model.BenutzerModel;
 import de.bund.bva.isyfact.benutzerverwaltung.gui.common.model.RolleModel;
-import de.bund.bva.isyfact.common.web.global.AbstractMaskenModel;
-
-import java.util.ArrayList;
-import java.util.List;
+import de.bund.bva.isyfact.benutzerverwaltung.gui.common.model.SucheModel;
 
 /**
  * Dieses Model stellt die Daten zur Rollenzuweisung-Maske bereit.
@@ -33,7 +36,7 @@ import java.util.List;
  * @author Capgemini, Jonas Zitz
  * @author msg systems ag, Stefan Dellmuth
  */
-public class RollenZuweisungModel extends AbstractMaskenModel {
+public class RollenZuweisungModel extends SucheModel<BenutzerModel, BenutzerSuchkriterienModel> {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -42,19 +45,19 @@ public class RollenZuweisungModel extends AbstractMaskenModel {
     private List<RolleModel> alleRollen;
 
     /**
-     * Selektierte Rollen, zur Anzeige der ausgewählten Rollen in der Auswahlliste.
+     * Liste aller Status zur Anzeige in einer Auswahlliste.
      */
-    private String selektierteRollenId;
+    private final List<BenutzerStatus> alleBenutzerStatus = Arrays.asList(BenutzerStatus.values());
 
     /**
-     * Liste aller Benutzer zur Anzeige in einer Auswahlliste.
+     * Id der ausgewählten Rolle.
      */
-    private List<BenutzerModel> alleBenutzer = new ArrayList<>();
+    private String ausgewaehlteRollenId;
 
     /**
-     * Selektierte Benutzernamen für die selektierte Rolle.
+     * Liste der ausgewählten Benutzer.
      */
-    private List<String> benutzerZuRolle = new ArrayList<>();
+    private List<BenutzerModel> ausgewaehlteBenutzer;
 
     public List<RolleModel> getAlleRollen() {
         return alleRollen;
@@ -64,28 +67,27 @@ public class RollenZuweisungModel extends AbstractMaskenModel {
         this.alleRollen = alleRollen;
     }
 
-    public String getSelektierteRollenId() {
-        return selektierteRollenId;
+    public List<BenutzerStatus> getAlleBenutzerStatus() {
+        return alleBenutzerStatus;
     }
 
-    public void setSelektierteRollenId(String selektierteRollenId) {
-        this.selektierteRollenId = selektierteRollenId;
+    public String getAusgewaehlteRollenId() {
+        return ausgewaehlteRollenId;
     }
 
-    public List<BenutzerModel> getAlleBenutzer() {
-        return alleBenutzer;
+    public void setAusgewaehlteRollenId(String ausgewaehlteRollenId) {
+        this.ausgewaehlteRollenId = ausgewaehlteRollenId;
     }
 
-    public void setAlleBenutzer(List<BenutzerModel> alleBenutzer) {
-        this.alleBenutzer = alleBenutzer;
+    public List<BenutzerModel> getAusgewaehlteBenutzer() {
+        return ausgewaehlteBenutzer;
     }
 
-    public List<String> getBenutzerZuRolle() {
-        return benutzerZuRolle;
+    public void setAusgewaehlteBenutzer(List<BenutzerModel> ausgewaehlteBenutzer) {
+        this.ausgewaehlteBenutzer = ausgewaehlteBenutzer;
     }
 
-    public void setBenutzerZuRolle(List<String> benutzerZuRolle) {
-        this.benutzerZuRolle = benutzerZuRolle;
+    public String getRollen(BenutzerModel benutzerModel) {
+        return benutzerModel.getRollen().stream().map(RolleModel::getRollenId).collect(Collectors.joining(", "));
     }
-
 }

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/gui/common/konstanten/HinweisSchluessel.java
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/java/de/bund/bva/isyfact/benutzerverwaltung/gui/common/konstanten/HinweisSchluessel.java
@@ -63,6 +63,11 @@ public abstract class HinweisSchluessel {
     public static final String SELFSERVICE_TOKEN_UNGUELTIG = "BENVW80008";
 
     /**
+     * Es wurde kein Benutzer ausgewählt.
+     */
+    public static final String KEIN_BENUTZER_AUSGEWAEHLT = "BENVW80009";
+
+    /**
      * Die Rolle '{0}' wurde erfolgreich erstellt.
      */
     public static final String ROLLE_ERSTELLT = "BENVW80011";

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenForm.xhtml
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenForm.xhtml
@@ -1,0 +1,103 @@
+<!--
+  #%L
+  IsyFact Benutzerverwaltung GUI mit Primefaces
+  %%
+  Copyright (C) 2016 - 2017 Bundesverwaltungsamt (BVA)
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui">
+
+    <f:loadBundle basename="resources.isy-benutzerverwaltung.nachrichten.maskentexte" var="msg_bnvw"/>
+
+    <p:panel header="#{msg_bnvw.MEL_RollenZuweisung_Suche}">
+        <div class="form-horizontal">
+            <div class="row row-df">
+                <div class="col-lg-6">
+                    <p:outputLabel for="nachname" value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_nachname}"/>
+                    <p:inputText id="nachname"
+                                 value="#{rollenZuweisenModel.trefferliste.suchkriterien.nachname}"
+                                 style="width:100%" tabindex="1000"/>
+                </div>
+                <div class="col-lg-6">
+                    <p:outputLabel for="status" value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_status}"/>
+                    <p:selectOneMenu id="status"
+                                     value="#{rollenZuweisenModel.trefferliste.suchkriterien.status}"
+                                     style="width:100%" tabindex="1003">
+                        <f:selectItem itemLabel="" itemValue="#{null}"/>
+                        <f:selectItems value="#{rollenZuweisenModel.alleBenutzerStatus}" var="status"
+                                       itemLabel="#{status.bezeichnung}" itemValue="#{status}"/>
+                    </p:selectOneMenu>
+                </div>
+            </div>
+            <div class="row row-df">
+                <div class="col-lg-6">
+                    <p:outputLabel for="vorname" value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_vorname}"/>
+                    <p:inputText id="vorname"
+                                 value="#{rollenZuweisenModel.trefferliste.suchkriterien.vorname}"
+                                 style="width:100%" tabindex="1001"/>
+                </div>
+                <div class="col-lg-6">
+                    <p:outputLabel for="rollen"
+                                   value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_rolle}"/>
+                    <p:selectOneMenu id="rollen"
+                                     value="#{rollenZuweisenModel.trefferliste.suchkriterien.rollenId}"
+                                     style="width:100%" tabindex="1004">
+                        <f:selectItem itemLabel="" itemValue="#{null}"/>
+                        <f:selectItems value="#{rollenZuweisenModel.alleRollen}" var="rolle"
+                                       itemLabel="#{rolle.rollenId}" itemValue="#{rolle.rollenId}"/>
+                    </p:selectOneMenu>
+                </div>
+            </div>
+            <div class="row row-df">
+                <div class="col-lg-6">
+                    <p:outputLabel for="benutzername"
+                                   value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_benutzername}"/>
+                    <p:inputText id="benutzername"
+                                 value="#{rollenZuweisenModel.trefferliste.suchkriterien.benutzername}"
+                                 style="width:100%" tabindex="1002"/>
+                </div>
+                <div class="col-lg-6">
+                    <p:outputLabel for="behoerde" value="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_behoerde}"/>
+                    <p:inputText id="behoerde"
+                                 value="#{rollenZuweisenModel.trefferliste.suchkriterien.behoerde}"
+                                 style="width:100%" tabindex="1005"/>
+                </div>
+            </div>
+        </div>
+    </p:panel>
+    <p:panel>
+        <div class="form-horizontal">
+            <div class="row row-df">
+                <div class="col-lg-6">
+                    <p:commandButton action="filterZuruecksetzen" id="filterZuruecksetzen" ajax="false"
+                                     value="#{msg_bnvw.MEL_FilterZuruecksetzen}"
+                                     tabindex="1006"/>
+                </div>
+                <div class="col-lg-6">
+                    <div class="pull-right">
+                        <p:commandButton action="suchen" id="suche" ajax="false"
+                                         value="#{msg_bnvw.MEL_Suchen}"
+                                         tabindex="1007"/>
+                        <p:defaultCommand target="suche"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </p:panel>
+</ui:composition>
+

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenTrefferliste.xhtml
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenTrefferliste.xhtml
@@ -1,0 +1,59 @@
+<!--
+  #%L
+  IsyFact Benutzerverwaltung GUI mit Primefaces
+  %%
+  Copyright (C) 2016 - 2017 Bundesverwaltungsamt (BVA)
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core" xmlns:p="http://primefaces.org/ui"
+                xmlns:h="http://java.sun.com/jsf/html">
+
+    <f:loadBundle basename="resources.isy-benutzerverwaltung.nachrichten.maskentexte" var="msg_bnvw"/>
+
+    <ui:fragment>
+        <p:panel header="#{msg_bnvw.MEL_RollenZuweisung_Ergebnis}">
+            <p:dataTable var="benutzer"
+                         selection="#{rollenZuweisenModel.ausgewaehlteBenutzer}"
+                         paginator="true" rows="10"
+                         paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                         rowsPerPageTemplate="10,25,50"
+                         currentPageReportTemplate="#{msg_bnvw.MEL_Trefferliste_TrefferGesamt}: #{rollenZuweisenModel.trefferliste.rowCount}"
+                         paginatorPosition="bottom"
+                         value="#{rollenZuweisenModel.trefferliste}" lazy="true"
+                         emptyMessage="#{msg_bnvw.MEL_Trefferliste_keineEintraege}">
+                <p:column selectionMode="multiple" style="width:36px;text-align:center"/>
+                <p:column sortBy="#{BenutzerSortierattribut.BENUTZERNAME}"
+                          headerText="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_benutzername}">
+                    <h:outputText value="#{benutzer.benutzername}" title="#{benutzer.benutzername}"/>
+                </p:column>
+
+                <p:column sortBy="#{BenutzerSortierattribut.NACHNAME}"
+                          headerText="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_nachname}">
+                    <h:outputText value="#{benutzer.nachname}" title="#{benutzer.nachname}"/>
+                </p:column>
+
+                <p:column sortBy="#{BenutzerSortierattribut.VORNAME}"
+                          headerText="#{msg_bnvw.MEL_BenutzerSuchen_benutzer_vorname}">
+                    <h:outputText value="#{benutzer.vorname}" title="#{benutzer.vorname}"/>
+                </p:column>
+
+                <p:column headerText="#{msg_bnvw.MEL_rolle}">
+                    <h:outputText value="#{rollenZuweisenModel.getRollen(benutzer)}" title="#{benutzer.benutzername}"/>
+                </p:column>
+            </p:dataTable>
+        </p:panel>
+    </ui:fragment>
+</ui:composition>

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/rolleZuweisenFlow.xml
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/rolleZuweisenFlow.xml
@@ -25,7 +25,7 @@
         http://www.springframework.org/schema/webflow/spring-webflow-2.4.xsd"
       parent="applikationseiteParentFlow">
 
-    <secured attributes="Benutzerverwaltung.Benutzer.Aendern"/>
+    <secured attributes="Benutzerverwaltung.Benutzer.Suchen,Benutzerverwaltung.Benutzer.Aendern"/>
 
     <var name="rollenZuweisenModel"
          class="de.bund.bva.isyfact.benutzerverwaltung.gui.benutzerverwaltung.rollenzuweisung.RollenZuweisungModel"/>
@@ -38,21 +38,30 @@
     <view-state id="rolleZuweisenViewState" model="rollenZuweisenModel">
         <attribute name="headlineKey" value="MAS_Rollenverwaltung_Headline"/>
 
-        <!-- Waehle alle Benutzer aus -->
-        <transition on="alleAuswaehlen" to="alleAuswaehlen">
-            <evaluate
-                    expression="rolleZuweisenController.alleAuswaehlen(rollenZuweisenModel)"/>
+        <transition on="filterZuruecksetzen" to="rolleZuweisenViewState">
+            <evaluate expression="rolleZuweisenController.filterZuruecksetzen(rollenZuweisenModel)"/>
         </transition>
-
-        <!-- aktualisiere Benutzer Rollenzuweisungen -->
-        <transition on="aktualisiereBenutzerRollenZuweisung" to="rolleZuweisenViewState">
-            <evaluate
-                    expression="rolleZuweisenController.aktualisiereRollenAllerBenutzer(rollenZuweisenModel)"/>
-            <evaluate expression="rolleZuweisenController.initialisiereModel(rollenZuweisenModel)"/>
-        </transition>
-
-        <transition on="back" to="end"/>
+        <transition on="suchen" to="trefferlisteViewState"/>
     </view-state>
 
-    <end-state id="end"></end-state>
+    <view-state id="trefferlisteViewState">
+        <attribute name="headlineKey" value="MAS_Benutzerverwaltung_Headline"/>
+
+        <on-entry>
+            <evaluate expression="rolleZuweisenController.zeigeSuchfehlerAn(rollenZuweisenModel)"/>
+        </on-entry>
+
+        <transition on="filterZuruecksetzen" to="trefferlisteViewState">
+            <evaluate expression="rolleZuweisenController.filterZuruecksetzen(rollenZuweisenModel)"/>
+        </transition>
+        <transition on="suchen" to="trefferlisteViewState"/>
+        <transition on="rolleZuweisen" to="trefferlisteViewState">
+            <evaluate expression="rolleZuweisenController.rolleZuweisen(rollenZuweisenModel, false)"/>
+        </transition>
+        <transition on="rolleEntziehen" to="trefferlisteViewState">
+            <evaluate expression="rolleZuweisenController.rolleZuweisen(rollenZuweisenModel, true)"/>
+        </transition>
+    </view-state>
+
+    <end-state id="end"/>
 </flow>

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/rollenAuswahl.xhtml
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/rollenAuswahl.xhtml
@@ -1,0 +1,54 @@
+<!--
+  #%L
+  IsyFact Benutzerverwaltung GUI mit Primefaces
+  %%
+  Copyright (C) 2016 - 2017 Bundesverwaltungsamt (BVA)
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core" xmlns:p="http://primefaces.org/ui"
+>
+
+    <f:loadBundle basename="resources.isy-benutzerverwaltung.nachrichten.maskentexte" var="msg_bnvw"/>
+
+    <ui:fragment>
+        <p:panel header="#{msg_bnvw.MEL_RollenZuweisung_Titel}">
+            <div class="form-horizontal">
+                <div class="row row-df">
+                    <div class="col-lg-6">
+                        <p:selectOneMenu id="rollenAuswahl" value="#{rollenZuweisenModel.ausgewaehlteRollenId}"
+                                              label="#{msg_bnvw.MEL_rolle}">
+                            <f:selectItems value="#{rollenZuweisenModel.alleRollen}" var="rolle"
+                                           itemLabel="#{rolle.rollenId} (#{rolle.rollenName})"
+                                           itemValue="#{rolle.rollenId}"/>
+                        </p:selectOneMenu>
+                    </div>
+                    <div class="col-lg-6">
+                        <div class="pull-right">
+                            <p:commandButton action="rolleZuweisen" id="rolleZuweisen" ajax="false"
+                                             value="#{msg_bnvw.MEL_RollenZuweisung_RolleZuweisen}"
+                                             tabindex="1020"/>
+                        </div>
+                        <div class="pull-right">
+                            <p:commandButton action="rolleEntziehen" id="rolleEntziehen" ajax="false"
+                                             value="#{msg_bnvw.MEL_RollenZuweisung_RolleEntziehen}"
+                                             tabindex="1021"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </p:panel>
+    </ui:fragment>
+</ui:composition>

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/trefferlisteViewState.xhtml
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/META-INF/resources/WEB-INF/gui/benutzerverwaltung/rollezuweisen/trefferlisteViewState.xhtml
@@ -1,6 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--
   #%L
   IsyFact Benutzerverwaltung GUI mit Primefaces
@@ -23,10 +20,17 @@
 
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
                 template="/WEB-INF/gui/common/benutzerverwaltung-applikation.xhtml">
+
+    <f:loadBundle basename="resources.isy-benutzerverwaltung.nachrichten.maskentexte" var="msg_bnvw"/>
 
     <ui:define name="inhaltsbereich">
         <ui:include src="/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenForm.xhtml"/>
+        <br/>
+        <ui:include src="/WEB-INF/gui/benutzerverwaltung/rollezuweisen/benutzerSuchenTrefferliste.xhtml"/>
+        <br/>
+        <ui:include src="/WEB-INF/gui/benutzerverwaltung/rollezuweisen/rollenAuswahl.xhtml"/>
     </ui:define>
 
 </ui:composition>

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/resources/isy-benutzerverwaltung/nachrichten/hinweise_de.properties
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/resources/isy-benutzerverwaltung/nachrichten/hinweise_de.properties
@@ -25,6 +25,7 @@ BENVW80005=Die Rollenzuordnungen zu den gew\u00E4hlten Benutzern wurden erfolgre
 BENVW80006=Das Passwort wurde erfolgreich zur\u00FCckgesetzt.
 BENVW80007=Sie haben Ihr Passwort erfolgreich ge\u00E4ndert.
 BENVW80008=Das Token ist nicht vorhanden oder abgelaufen.
+BENVW80009=Es wurde kein Benutzer ausgew\u00E4hlt.
 BENVW80011=Die Rolle "{0}" wurde erfolgreich angelegt.
 BENVW80012=Die Rolle "{0}" wurde erfolgreich gespeichert.
 BENVW80013=Die Rolle "{0}" wurde erfolgreich gel\u00F6scht.

--- a/isy-benutzerverwaltung-gui-primefaces/src/main/resources/resources/isy-benutzerverwaltung/nachrichten/maskentexte_de.properties
+++ b/isy-benutzerverwaltung-gui-primefaces/src/main/resources/resources/isy-benutzerverwaltung/nachrichten/maskentexte_de.properties
@@ -107,9 +107,12 @@ MEL_BenutzerBearbeiten_Benutzerdaten=Benutzerdaten
 MEL_BenutzerBearbeiten_Kontaktdaten=Kontaktdaten
 
 # Rollenzuweisung
+MEL_RollenZuweisung_Suche = Sucheingabe - Nutzer zur Rollenzuweisung suchen
+MEL_RollenZuweisung_Ergebnis = Suchergebnis - Nutzer zur Rollenzuweisung auswählen
 MEL_RollenZuweisung_Titel = Zuordnung von Rollen zu Benutzern bearbeiten
-MEL_RollenZuweisung_RollenZuweisungBearbeiten = Rollenzuweisungen bearbeiten
-MEL_RollenZuweisung_BenutzerRollenZugewiesen = Benutzer, die der gew\u00E4hlten Rolle zugewiesen sind
+MEL_RollenZuweisung_RolleZuweisen = Rolle zuweisen
+MEL_RollenZuweisung_RolleEntziehen = Rolle Entziehen
+MEL_Rollenzuweisung_Rollenauswahl = Rollenauswahl
 
 # Selfservice
 MEL_Selfservice_PasswortZuruecksetzen = Passwort zur\u00FCcksetzen


### PR DESCRIPTION
Neue Maske für Rollenzuweisung mit 3 Schritten:

1. Suche der zu ändernden Nutzer über Suchkriterien vergleichbar mit  Funktion Benutzer suchen
1. Auswahl der zu ändernden Nutzer im Suchergebnis per Checkbox
1. Auswahl der Rolle aus Dropdown und anschließend diese Rolle den ausgewählten Nutzern zuweisen oder entziehen

Zusätzlich Feld `rollen` in Entität `Benutzer` von `List<Rolle>` auf `Set<Rolle>` geändert, damit nicht die gleiche Rolle mehrfach zugewiesen werden kann